### PR TITLE
$(…).on() instead of $(…).live()

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -98,7 +98,7 @@
 		*  @return	n/a
 		*/
 		
-		$(document).live('acf/setup_fields', function(e, postbox){
+		$(document).on('acf/setup_fields', function(e, postbox){
 			
 			$(postbox).find('.field[data-field_type="range"]').each(function(){
 				

--- a/js/range.js
+++ b/js/range.js
@@ -3,7 +3,7 @@
  */
 (function($){
 	
-	$(document).live('acf/setup_fields', function(e, postbox){
+	$(document).on('acf/setup_fields', function(e, postbox){
 		$(postbox).find('div.am_range_amount').each(function(){
 			var box = $(this);
 			var slider = box.find('div.am_range')


### PR DESCRIPTION
[.live()](http://api.jquery.com/live/) is deprecated since jQuery 1.7 and was removed in jQuery 1.9